### PR TITLE
Add single shot mode

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 import yaml
-from pydantic import BaseModel, PositiveInt, DirectoryPath, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    NonNegativeInt,
+    PositiveInt,
+    DirectoryPath,
+    ConfigDict,
+    Field,
+)
 from typing import Optional
 
 from src import constants
@@ -25,7 +32,7 @@ class DataCollectorSettings(BaseModel):
 
     # Optional settings with defaults
     identity_id: str = "unknown"
-    collection_interval: PositiveInt = constants.DATA_COLLECTOR_COLLECTION_INTERVAL
+    collection_interval: NonNegativeInt = constants.DATA_COLLECTOR_COLLECTION_INTERVAL
     cleanup_after_send: bool = True
     ingress_connection_timeout: PositiveInt = (
         constants.DATA_COLLECTOR_CONNECTION_TIMEOUT

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -74,6 +74,16 @@ class TestDataCollectorSettings:
 
             assert "greater_than" in str(exc_info.value)
 
+    def test_zero_collection_interval(self):
+        """Test validation error for negative collection interval."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            DataCollectorSettings(
+                data_dir=Path(tmpdir),
+                service_id="test-service",
+                ingress_server_url="https://example.com/api/v1/upload",
+                collection_interval=0,
+            )
+
     def test_from_yaml_valid_file(self):
         """Test loading settings from a valid YAML file."""
         config_data = {


### PR DESCRIPTION
This is useful for environments such as OpenShift/K8s where it is natural to use CronJob resources to run periodic tasks such as this.

It is more efficient on cluster resources to run it this way without sacrificing any timeliness of data collection.

The single shot mode is activated by setting the collection_interval to 0.