### PR TITLE
Accept auth token from envvar

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -84,6 +84,7 @@ If testing against the stage environment, generate an ingress auth token from yo
 # Get your offline token from https://access.stage.redhat.com/management/api
 # Then generate the ingress auth token:
 python scripts/ingress_token_from_offline_token.py --offline-token YOUR_OFFLINE_TOKEN --env stage
+export INGRESS_SERVER_AUTH_TOKEN="your-auth-token"
 ```
 
 **Create test configuration:**
@@ -92,7 +93,6 @@ cat > test-config.yaml << 'EOF'
 data_dir: "./test-data"
 service_id: "your-service-id"
 ingress_server_url: "https://your-stage-ingress-url/api/v1/data/ingest"  # use staging for testing
-ingress_server_auth_token: "your-auth-token"  # use token from script above
 identity_id: "test-instance"
 collection_interval: 60
 cleanup_after_send: false

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ uv run python -m src.main --mode manual --config config.yaml \
   --identity-id YOUR_IDENTITY
 ```
 - Requires explicit credentials
+- The auth token can either be specified as a command arg as above or via the envvar `INGRESS_SERVER_AUTH_TOKEN`.
 - Use `scripts/ingress_token_from_offline_token.py` to generate tokens for stage testing
 
 ### Common Options

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@
 import argparse
 import logging
 import sys
+from os import environ
 from pathlib import Path
 from src.settings import DataCollectorSettings
 from src.data_exporter import DataCollectorService
@@ -208,6 +209,10 @@ def main() -> int:
             config_dict["ingress_server_url"] = args.ingress_server_url
         if args.ingress_server_auth_token:
             config_dict["ingress_server_auth_token"] = args.ingress_server_auth_token
+        elif "INGRESS_SERVER_AUTH_TOKEN" in environ:
+            config_dict["ingress_server_auth_token"] = environ[
+                "INGRESS_SERVER_AUTH_TOKEN"
+            ]
         if args.identity_id:
             config_dict["identity_id"] = args.identity_id
         if args.collection_interval:


### PR DESCRIPTION
The name of the envvar is INGRESS_SERVER_AUTH_TOKEN.

This is useful for environments where secrets in cli args are not allowed or desirable.