### PR TITLE
Use constant value for retry

### DIFF
--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -18,6 +18,7 @@ import requests
 
 from src.file_handler import FileHandler
 from src.ingress_client import IngressClient
+from src.constants import DATA_COLLECTOR_RETRY_INTERVAL
 from src.settings import DataCollectorSettings
 
 logger = logging.getLogger(__name__)
@@ -173,8 +174,10 @@ class DataCollectorService:
                     raise e
 
                 if not self.shutdown_event.is_set():
-                    logger.info("Retrying in %d seconds...", self.collection_interval)
-                    _ = self.shutdown_event.wait(self.collection_interval)
+                    logger.info(
+                        "Retrying in %d seconds...", DATA_COLLECTOR_RETRY_INTERVAL
+                    )
+                    _ = self.shutdown_event.wait(DATA_COLLECTOR_RETRY_INTERVAL)
 
         logger.info("Doing one final collection before shutdown")
         # Exceptions (other than KeyboardInterrupt) here should bubble up because they indicate

--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -14,6 +14,7 @@ from src.data_exporter import (
     package_files_into_tarball,
 )
 from src.settings import DataCollectorSettings
+from src.constants import DATA_COLLECTOR_RETRY_INTERVAL
 
 
 # Note: FilterAllowedFiles and CollectFiles tests moved to test_file_handler.py
@@ -375,3 +376,39 @@ class TestDataCollectorServiceRun:
                 assert (
                     False
                 ), "service should have reraised exception when in single shot mode"
+
+    @patch("src.file_handler.FileHandler.collect_files")
+    @patch("src.data_exporter.logger")
+    def test_retry_uses_correct_interval(self, mock_logger, mock_collect):
+        """Test that retry logic uses DATA_COLLECTOR_RETRY_INTERVAL constant."""
+        # Mock collect_files to raise an exception on first call, then KeyboardInterrupt
+        call_count = 0
+
+        def mock_collect_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise requests.RequestException("Network error")
+            else:
+                raise KeyboardInterrupt()  # Exit the loop on subsequent calls
+
+        mock_collect.side_effect = mock_collect_side_effect
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = create_test_config(data_dir=Path(tmpdir))
+            service = DataCollectorService(config)
+
+            # Mock the shutdown_event.wait method to capture the retry interval
+            with patch.object(service.shutdown_event, "wait") as mock_wait:
+                # First call returns False (not set), second call can return True or raise KeyboardInterrupt
+                mock_wait.side_effect = [False, KeyboardInterrupt()]
+
+                service.run()
+
+                # Verify that wait was called with the correct retry interval
+                mock_wait.assert_called_with(DATA_COLLECTOR_RETRY_INTERVAL)
+
+                # Verify the log message includes the correct interval
+                mock_logger.info.assert_any_call(
+                    "Retrying in %d seconds...", DATA_COLLECTOR_RETRY_INTERVAL
+                )


### PR DESCRIPTION
Replace hardcoded collection_interval with the dedicated DATA_COLLECTOR_RETRY_INTERVAL constant (300s) in the retry logic. This separates retry timing (5 minutes) from collection timing (2 hours).

- Use DATA_COLLECTOR_RETRY_INTERVAL constant in retry wait logic
- Add test to verify correct retry interval is used