### PR TITLE
Decrease wait in tests

### DIFF
--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -192,8 +192,9 @@ class TestPackageFilesIntoTarball:
                 assert "symlink.json" not in members  # Symlink should be skipped
 
 
-def stop_after_delay(service: DataCollectorService):
-    time.sleep(2)
+def stop_service(service: DataCollectorService):
+    # Small delay to allow service to process at least one iteration
+    time.sleep(0.1)
     service.shutdown()
 
 
@@ -211,7 +212,7 @@ class TestDataCollectorServiceRun:
             config = create_test_config(data_dir=Path(tmpdir))
             service = DataCollectorService(config)
 
-            threading.Thread(target=stop_after_delay, args=[service]).start()
+            threading.Thread(target=stop_service, args=[service]).start()
             service.run()
 
             mock_collect.assert_called()
@@ -259,7 +260,7 @@ class TestDataCollectorServiceRun:
             service = DataCollectorService(config)
 
             with patch.object(service.ingress_client, "upload_tarball"):
-                threading.Thread(target=stop_after_delay, args=[service]).start()
+                threading.Thread(target=stop_service, args=[service]).start()
                 service.run()
 
             # Verify data processing workflow
@@ -295,7 +296,7 @@ class TestDataCollectorServiceRun:
             service = DataCollectorService(config)
 
             with patch.object(service.ingress_client, "upload_tarball"):
-                threading.Thread(target=stop_after_delay, args=[service]).start()
+                threading.Thread(target=stop_service, args=[service]).start()
                 service.run()
 
             # Verify cleanup functions are not called
@@ -313,7 +314,7 @@ class TestDataCollectorServiceRun:
             config = create_test_config(data_dir=Path(tmpdir))
             service = DataCollectorService(config)
 
-            threading.Thread(target=stop_after_delay, args=[service]).start()
+            threading.Thread(target=stop_service, args=[service]).start()
             service.run()
 
             # Should log error and retry
@@ -335,7 +336,7 @@ class TestDataCollectorServiceRun:
             config = create_test_config(data_dir=Path(tmpdir))
             service = DataCollectorService(config)
 
-            threading.Thread(target=stop_after_delay, args=[service]).start()
+            threading.Thread(target=stop_service, args=[service]).start()
             service.run()
 
             # Should log error about the exception


### PR DESCRIPTION
Significantly improve test performance by optimizing the stop_after_delay helper function used in DataCollectorService tests.

- Reduce delay from 2 seconds to 0.1 seconds in test helper function
- Test suite execution time reduced from ~10+ seconds to ~0.64 seconds

The minimal 0.1-second delay ensures the service can process at least one iteration before shutdown, maintaining test accuracy while eliminating the unnecessary 2-second wait that was slowing down the entire test suite.
