### PR TITLE
Make retry interval configurable

### DIFF
--- a/src/data_exporter.py
+++ b/src/data_exporter.py
@@ -18,7 +18,7 @@ import requests
 
 from src.file_handler import FileHandler
 from src.ingress_client import IngressClient
-from src.constants import DATA_COLLECTOR_RETRY_INTERVAL
+
 from src.settings import DataCollectorSettings
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,7 @@ class DataCollectorService:
         self.data_dir = config.data_dir
         self.collection_interval = config.collection_interval
         self.cleanup_after_send = config.cleanup_after_send
+        self.retry_interval = config.retry_interval
 
         # Initialize file handler for this service
         self.file_handler = FileHandler(
@@ -174,10 +175,8 @@ class DataCollectorService:
                     raise e
 
                 if not self.shutdown_event.is_set():
-                    logger.info(
-                        "Retrying in %d seconds...", DATA_COLLECTOR_RETRY_INTERVAL
-                    )
-                    _ = self.shutdown_event.wait(DATA_COLLECTOR_RETRY_INTERVAL)
+                    logger.info("Retrying in %d seconds...", self.retry_interval)
+                    _ = self.shutdown_event.wait(self.retry_interval)
 
         logger.info("Doing one final collection before shutdown")
         # Exceptions (other than KeyboardInterrupt) here should bubble up because they indicate

--- a/src/main.py
+++ b/src/main.py
@@ -106,6 +106,12 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--retry-interval",
+        type=int,
+        help="Retry interval in seconds when collection fails",
+    )
+
+    parser.add_argument(
         "--no-cleanup",
         action="store_true",
         help="Do not clean up files after successful send",
@@ -220,6 +226,8 @@ def main() -> int:
             config_dict["collection_interval"] = args.collection_interval
         if args.ingress_connection_timeout:
             config_dict["ingress_connection_timeout"] = args.ingress_connection_timeout
+        if args.retry_interval:
+            config_dict["retry_interval"] = args.retry_interval
         if args.no_cleanup:
             config_dict["cleanup_after_send"] = False
         if args.allowed_subdirs:
@@ -246,6 +254,9 @@ def main() -> int:
         )
         config_dict.setdefault(
             "ingress_connection_timeout", constants.DATA_COLLECTOR_CONNECTION_TIMEOUT
+        )
+        config_dict.setdefault(
+            "retry_interval", constants.DATA_COLLECTOR_RETRY_INTERVAL
         )
         config_dict.setdefault("cleanup_after_send", True)
         config_dict.setdefault("allowed_subdirs", [])

--- a/src/settings.py
+++ b/src/settings.py
@@ -37,6 +37,7 @@ class DataCollectorSettings(BaseModel):
     ingress_connection_timeout: PositiveInt = (
         constants.DATA_COLLECTOR_CONNECTION_TIMEOUT
     )
+    retry_interval: PositiveInt = constants.DATA_COLLECTOR_RETRY_INTERVAL
     allowed_subdirs: list[str] = Field(default_factory=list)
 
     @classmethod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -197,6 +197,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         mock_get_auth.return_value = ("openshift-token", "openshift-identity")
@@ -247,6 +248,7 @@ class TestMain:
         mock_args.no_cleanup = True
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         mock_get_auth.return_value = ("test-token", "test-identity")
@@ -288,6 +290,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         with pytest.raises(SystemExit) as exc_info:
@@ -316,6 +319,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         from src.auth import AuthenticationError
@@ -348,6 +352,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         mock_get_auth.return_value = ("test-token", "test-identity")
@@ -382,6 +387,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
         mock_parse_args.return_value = mock_args
 
         mock_get_auth.return_value = ("test-token", "test-identity")
@@ -412,6 +418,7 @@ class TestMain:
         mock_args.no_cleanup = False
         mock_args.rich_logs = False
         mock_args.allowed_subdirs = None
+        mock_args.retry_interval = None
 
         # Apply any test-specific overrides
         for key, value in overrides.items():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,7 @@ class TestDataCollectorSettings:
             collection_interval=300,
             cleanup_after_send=True,
             ingress_connection_timeout=30,
+            retry_interval=120,
         )
 
         assert settings.data_dir == Path("/tmp")
@@ -33,6 +34,7 @@ class TestDataCollectorSettings:
         assert settings.collection_interval == 300
         assert settings.cleanup_after_send is True
         assert settings.ingress_connection_timeout == 30
+        assert settings.retry_interval == 120
 
     def test_settings_with_defaults(self):
         """Test settings creation with default values."""
@@ -48,6 +50,7 @@ class TestDataCollectorSettings:
         assert settings.collection_interval == 7200  # Default from constants
         assert settings.cleanup_after_send is True
         assert settings.ingress_connection_timeout == 30  # Default from constants
+        assert settings.retry_interval == 300  # Default from constants
         assert settings.allowed_subdirs == []  # Default: collect everything
 
     def test_invalid_data_dir(self):
@@ -95,6 +98,7 @@ class TestDataCollectorSettings:
             "collection_interval": 600,
             "cleanup_after_send": False,
             "ingress_connection_timeout": 60,
+            "retry_interval": 180,
         }
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -114,6 +118,7 @@ class TestDataCollectorSettings:
             assert settings.collection_interval == 600
             assert settings.cleanup_after_send is False
             assert settings.ingress_connection_timeout == 60
+            assert settings.retry_interval == 180
             assert settings.allowed_subdirs == []  # Default when not in YAML
         finally:
             config_file.unlink()


### PR DESCRIPTION
This PR makes the retry interval for failed data collection attempts configurable through the settings system, allowing users to customize the wait time between retries instead of using a hardcoded constant.